### PR TITLE
Changed access to resources due to assembly name change

### DIFF
--- a/src/Conditions/SR.cs
+++ b/src/Conditions/SR.cs
@@ -112,7 +112,7 @@ namespace Conditions
         internal const string ValueShouldNotBePositiveInfinity = "ValueShouldNotBePositiveInfinity";
 
         private static readonly ResourceManager resource =
-            new ResourceManager(typeof (SR).Namespace + ".ExceptionMessages", typeof (SR).GetTypeInfo().Assembly);
+            new ResourceManager(typeof (SR).GetTypeInfo().Assembly.GetName().Name + ".ExceptionMessages", typeof (SR).GetTypeInfo().Assembly);
 
         // Returns a string from the resource.
         internal static string GetString(string name)


### PR DESCRIPTION
Changed the access to the resources. 

Since the assembly is renamed, the original code doesn't find the resources which results in an exception.